### PR TITLE
Fix building for zsh

### DIFF
--- a/tests/t.sh
+++ b/tests/t.sh
@@ -257,11 +257,15 @@ Tenko CLI Toolkit help:
     p6)
       ACTION='perf6'
       ;;
-    c8);&
-    coverage):
+    c8)
       ACTION='coverage'
       ;;
-    d);&
+    coverage)
+      ACTION='coverage'
+      ;;
+    d)
+      ACTION='doptigate'
+      ;;
     deoptigate)
       ACTION='doptigate'
       ;;
@@ -297,7 +301,7 @@ Tenko CLI Toolkit help:
     --no-fatals)    EXTRA='--no-fatals'   ;;
     --concise)      EXTRA='--concise'     ;;
     -q)             EXTRA='-q'            ;;
-    -b);&
+    -b)             BUILD='-b'            ;;
     --build)        BUILD='-b'            ;;
     --nb)           NO_BUILDING='--nb'    ;;
     --no-compat)    NOCOMP='--no-compat'  ;;


### PR DESCRIPTION
The file t.sh is using ";&" for cases and that seems to be compatible
with bash but not with zsh. As Apple has replaced bash by zsh back in
2019 the script is not working out of the box in current Mac computers.

I have fixed the issue by removing that notation and so the current
script should work without issues in both bash and zsh.